### PR TITLE
Fixed a crash of MoleculeNetDataset when faulty smiles are encountered

### DIFF
--- a/kgcnn/data/base.py
+++ b/kgcnn/data/base.py
@@ -399,10 +399,23 @@ class MemoryGraphList:
         return self
 
     def obtain_property(self, key):
+        r"""Returns a list with the values of all the graphs defined for the string property name `key`. If none of
+        the graphs in the list have this property, returns None.
+
+        Args:
+            key (str): The string name of the property to be retrieved for all the graphs contained in this list
+        """
+        # "_list" is a list of GraphNumpyContainers, which means "prop_list" here will be a list of all the property
+        # values for teach of the graphs which make up this list.
         prop_list = [x.obtain_property(key) for x in self._list]
+
+        # If a certain string property is not set for a GraphNumpyContainer, it will still return None. Here we check:
+        # If all the items for our given property name are None then we know that this property is generally not
+        # defined for any of the graphs in the list.
         if all([x is None for x in prop_list]):
             self.logger.warning("Property %s is not set on any graph." % key)
             return None
+
         return prop_list
 
     def __setattr__(self, key, value):
@@ -494,6 +507,14 @@ class MemoryGraphList:
         return self
 
     def clean(self, inputs: list):
+        """Given a list of property names, this method removes all elements from the internal list of
+        GraphNumpyContainers, which do not define at least one of those properties. Aka only those graphs remain in
+        the list which definitely define all of the properties.
+
+        Args:
+            inputs (list): A list of strings, where each string is supposed to be a property name, which the graphs
+                in this list may possess.
+        """
         invalid_graphs = []
         for item in inputs:
             if isinstance(item, dict):

--- a/kgcnn/data/moleculenet.py
+++ b/kgcnn/data/moleculenet.py
@@ -193,7 +193,7 @@ class MoleculeNetDataset(MemoryGraphDataset):
         self.assign_property("node_symbol", node_symbol)
         self.assign_property("node_coordinates",  node_coordinates)
         self.assign_property("node_number", node_number)
-        self.assign_property("graph_size", [len(x) for x in node_number])
+        self.assign_property("graph_size", [None if x is None else len(x) for x in node_number])
         self.assign_property("edge_indices", edge_indices)
         self.assign_property("graph_labels", graph_labels)
         self.assign_property("edge_number", edge_number)
@@ -302,7 +302,7 @@ class MoleculeNetDataset(MemoryGraphDataset):
             if i % 1000 == 0:
                 self.info(" ... read molecules {0} from {1}".format(i, num_mols))
 
-        self.assign_property("graph_size", [len(x) for x in node_attributes])
+        self.assign_property("graph_size", [None if x is None else len(x) for x in node_number])
         self.assign_property("graph_attributes", graph_attributes)
         self.assign_property("node_attributes", node_attributes)
         self.assign_property("edge_attributes", edge_attributes)


### PR DESCRIPTION
In MoleculeNetDataset ".read_in_memory" and ".set_attributes" methods: if molecule is None, None is added for every property list. Further down there is the following line however:

```python
self.assign_property("graph_size", [len(x) for x in node_attributes]
```
When iterating over one of the None elements in `node_attributes` there was an Exception `NoneType object has no attribute length`.

Changed the list comprehension to account for that.
