### PR TITLE
Moleculenet changes

### DIFF
--- a/kgcnn/data/moleculenet.py
+++ b/kgcnn/data/moleculenet.py
@@ -324,6 +324,8 @@ class MoleculeNetDataset(MemoryGraphDataset):
 
         return self
 
+    # def _map_molecule_attributes(self, callbacks: ):
+
     @staticmethod
     def _deserialize_encoder(encoder_identifier):
         """Serialization. Will maybe include keras in the future.

--- a/test/test_data_moleculenet.py
+++ b/test/test_data_moleculenet.py
@@ -1,0 +1,103 @@
+import unittest
+import tempfile
+import os
+
+import numpy as np
+from rdkit import RDLogger
+RDLogger.DisableLog('rdApp.*')
+
+from kgcnn.data.moleculenet import MoleculeNetDataset
+
+
+SIMPLE_SMILES_CSV = """
+index,name,label,smiles
+1,Propanolol,1,[Cl].CC(C)NCC(O)COc1cccc2ccccc12
+2,Terbutylchlorambucil,1,C(=O)(OC(C)(C)C)CCCc1ccc(cc1)N(CCCl)CCCl
+3,40730,1,c12c3c(N4CCN(C)CC4)c(F)cc1c(c(C(O)=O)cn2C(C)CO3)=O
+4,24,1,C1CCN(CC1)Cc1cccc(c1)OCCCNC(=O)C
+"""
+
+
+FAULTY_SMILES_CSV = """
+index,name,label,smiles
+57,compound 36,1,CN(C)Cc1ccc(CSCCNC2=C([N+]([O-])=O)C(Cc3ccccc3)=CN2)o1
+58,19,0,CNC(=NC#N)Nc1cccc(c1)c1csc(n1)N=C(N)N
+59,Y-G 14,1,n(ccc1)c(c1)CCNC
+60,15,1,O=N([O-])C1=C(CN=C1NCCSCc2ncccc2)Cc3ccccc3
+"""
+
+
+class TestMoleculeNetDataset(unittest.TestCase):
+
+    # MoleculeNetDataset needs a folder in which it can operate. We create a fixture which will set up a new temp
+    # folder for each test case.
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.temp_dir = None
+        self.temp_path = None
+        self.file_name = 'test.csv'
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = self.temp_dir.__enter__()
+
+    def tearDown(self):
+        self.temp_dir.__exit__(None, None, None)
+
+    # This is a utility method. It will create a CSV file as the source for the dataset in the current temporary folder
+    # using the string CSV content
+    def write_string(self, string: str):
+        with open(os.path.join(self.temp_path, self.file_name), mode='w') as file:
+            file.write(string)
+
+    # ~ ACTUAL TEST CASES
+
+    def test_construction_basically_works(self):
+        self.write_string(SIMPLE_SMILES_CSV)
+        molnet = MoleculeNetDataset(data_directory=self.temp_path, file_name=self.file_name, dataset_name='test')
+        self.assertIsInstance(molnet, MoleculeNetDataset)
+
+    def test_basically_works(self):
+        self.write_string(SIMPLE_SMILES_CSV)
+        molnet = MoleculeNetDataset(data_directory=self.temp_path, file_name=self.file_name, dataset_name='test')
+
+        molnet.prepare_data(
+            overwrite=False,
+            smiles_column_name='smiles'
+        )
+
+        molnet.read_in_memory(
+            label_column_name='label',
+            add_hydrogen=False,
+        )
+        # We know that this csv data has 4 entries
+        self.assertEqual(len(molnet), 4)
+
+        # Basic tests for one of the entries
+        data = molnet[1]
+        self.assertIsInstance(data, dict)
+        # These are the basic fields which every entry is supposed to have and all of them need to be
+        # numpy arrays
+        keys = ['graph_size', 'graph_labels', 'node_coordinates', 'node_number',
+                'node_symbol', 'edge_indices']
+        for key in keys:
+            self.assertIn(key, data)
+            print(type(data[key]))
+            self.assertIsInstance(data[key], np.ndarray)
+
+    def test_faulty_smiles_do_not_cause_exception(self):
+        self.write_string(FAULTY_SMILES_CSV)
+        molnet = MoleculeNetDataset(data_directory=self.temp_path, file_name=self.file_name, dataset_name='test')
+
+        molnet.prepare_data(
+            overwrite=False,
+            smiles_column_name='smiles'
+        )
+
+        molnet.read_in_memory(
+            label_column_name='label',
+            add_hydrogen=False,
+        )
+        self.assertEqual(len(molnet), 8)
+


### PR DESCRIPTION
Extended `MoleculeNetDataset` class to be able to add custom properties to the elements of the dataset. This required a rewrite of the methods `read_in_memory` and `set_attributes`. Their core functionality should still be the same -> Also added some basic unittests in `tests/test_data_moleculenet.py` to confirm.

The additional functionality is implemented as the new argument `additional_callbacks` for the `set_attributes` method.

Now it is possible to do something like this:

```python
dataset = MoleculeNetDataset(...)
dataset.prepare_data(smiles_column_name="smiles")
dataset.read_in_memory(labels_column_name="label")
# For every molecule in the dataset each callback is called with the first argument being the 
# MolecularRDKit instance and the second one being a dict which contains all the original CSV's 
# values for that particular molecule. The string names which are the keys for the callbacks are then 
# also used as the properties for the underlying MemoryGraphList
dataset.set_attributes(additional_callbacks={
    'name': lambda mg, dd: dd['name'],
    'node_count': lambda mg, dd: len(mg.node_number) 
})
molecule: dict = dataset[0]
molecule['name'] # name from the csv column "name"
molecule['node_count'] # essentially same as graph_size based on MolecularRDKit 
``` 