### PR TITLE
Added MEGAN model

### DIFF
--- a/kgcnn/hyper/hyper.py
+++ b/kgcnn/hyper/hyper.py
@@ -44,10 +44,10 @@ class HyperParameter:
             self._hyper_all = hyper_info
         else:
             raise TypeError("`HyperParameter` requires valid hyper dictionary or path to file.")
-
+        
         # If model and training section in hyper-dictionary, then this is a valid hyper setting.
         # If hyper is itself a dictionary with many models, pick the right model if model name is given.
-        model_name_class = "%s.%s" % (model_name, model_class)
+        model_name_class = "%s.%s" % (model_name, model_class)        
         if "model" in self._hyper_all and "training" in self._hyper_all:
             self._hyper = self._hyper_all
         elif model_name is not None and model_class == "make_model" and model_name in self._hyper_all:

--- a/kgcnn/layers/conv/gat_conv.py
+++ b/kgcnn/layers/conv/gat_conv.py
@@ -312,3 +312,13 @@ class MultiHeadGATV2Layer(AttentionHeadGATV2):
         # h_is: ([batch], [N], K * Vu) or ([batch], [N], Vu)
         # a_ijs: ([batch], [M], K, 1)
         return h_is, a_ijs
+
+    def get_config(self):
+        """Update layer config."""
+        config = super(MultiHeadGATV2Layer, self).get_config()
+        config.update({
+            'num_heads': self.num_heads,
+            'concat_heads': self.concat_heads
+        })
+
+        return config

--- a/kgcnn/layers/conv/gat_conv.py
+++ b/kgcnn/layers/conv/gat_conv.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 
 from kgcnn.layers.base import GraphBaseLayer
 from kgcnn.layers.gather import GatherNodesIngoing, GatherNodesOutgoing
-from kgcnn.layers.modules import DenseEmbedding, LazyConcatenate, ActivationEmbedding
+from kgcnn.layers.modules import DenseEmbedding, LazyConcatenate, LazyAverage, ActivationEmbedding
 from kgcnn.layers.pooling import PoolingLocalEdgesAttention
 
 
@@ -227,3 +227,88 @@ class AttentionHeadGATV2(GraphBaseLayer):
                   "bias_constraint", "kernel_initializer", "bias_initializer", "activation"]:
             config.update({x: conf_sub[x]})
         return config
+
+
+class MultiHeadGATV2Layer(AttentionHeadGATV2):
+
+    def __init__(self,
+                 units: int,
+                 num_heads: int,
+                 activation: str = 'kgcnn>leaky_relu',
+                 use_bias: bool = True,
+                 concat_heads: bool = True,
+                 **kwargs):
+        super(MultiHeadGATV2Layer, self).__init__(
+            units=units,
+            activation=activation,
+            use_bias=use_bias,
+            **kwargs
+        )
+        self.num_heads = num_heads
+        self.concat_heads = concat_heads
+
+        self.head_layers = []
+        for _ in range(num_heads):
+            lay_linear = DenseEmbedding(units, activation=activation, use_bias=use_bias)
+            lay_alpha_activation = DenseEmbedding(units, activation=activation, use_bias=use_bias)
+            lay_alpha = DenseEmbedding(1, activation='linear', use_bias=False)
+
+            self.head_layers.append((lay_linear, lay_alpha_activation, lay_alpha))
+
+        self.lay_concat_alphas = LazyConcatenate(axis=-2)
+        self.lay_concat_embeddings = LazyConcatenate(axis=-2)
+        self.lay_pool_attention = PoolingLocalEdgesAttention()
+        # self.lay_pool = PoolingLocalEdges()
+
+        if self.concat_heads:
+            self.lay_combine_heads = LazyConcatenate(axis=-1)
+        else:
+            self.lay_combine_heads = LazyAverage()
+
+    def __call__(self, inputs, **kwargs):
+        node, edge, edge_index = inputs
+
+        # "a_ij" is a single-channel edge attention logits tensor. "a_ijs" is consequently the list which
+        # stores these tensors for each attention head.
+        # "h_i" is a single-channel node embedding tensor. "h_is" is consequently the list which stores
+        # these tensors for each attention head.
+        a_ijs = []
+        h_is = []
+        for k, (lay_linear, lay_alpha_activation, lay_alpha) in enumerate(self.head_layers):
+
+            # Copied from the original class
+            w_n = lay_linear(node, **kwargs)
+            n_in = self.lay_gather_in([node, edge_index], **kwargs)
+            n_out = self.lay_gather_out([node, edge_index], **kwargs)
+            wn_out = self.lay_gather_out([w_n, edge_index], **kwargs)
+            if self.use_edge_features:
+                e_ij = self.lay_concat([n_in, n_out, edge], **kwargs)
+            else:
+                e_ij = self.lay_concat([n_in, n_out], **kwargs)
+
+            # a_ij: ([batch], [M], 1)
+            a_ij = lay_alpha_activation(e_ij, **kwargs)
+            a_ij = lay_alpha(a_ij, **kwargs)
+
+            # h_i: ([batch], [N], F)
+            h_i = self.lay_pool_attention([node, wn_out, a_ij, edge_index], **kwargs)
+
+            if self.use_final_activation:
+                h_i = self.lay_final_activ(h_i, **kwargs)
+
+            # a_ij after expand: ([batch], [M], 1, 1)
+            a_ij = tf.expand_dims(a_ij, axis=-2)
+            a_ijs.append(a_ij)
+
+            # h_i = tf.expand_dims(h_i, axis=-2)
+            h_is.append(h_i)
+
+        a_ijs = self.lay_concat_alphas(a_ijs)
+
+        h_is = self.lay_combine_heads(h_is)
+
+        # An important modification we need here is that this layer also returns the attention coefficients
+        # because in MEGAN we need those to calculate the edge attention values with!
+        # h_is: ([batch], [N], K * Vu) or ([batch], [N], Vu)
+        # a_ijs: ([batch], [M], K, 1)
+        return h_is, a_ijs

--- a/kgcnn/literature/MEGAN.py
+++ b/kgcnn/literature/MEGAN.py
@@ -1,7 +1,64 @@
+from typing import List, Tuple, Dict, Optional, Any
+
 import tensorflow as tf
+import tensorflow.keras as ks
+
+from kgcnn.layers.conv.attention import AttentionHeadGATV2
+from kgcnn.layers.base import GraphBaseLayer
 
 
-class MEGAN(tf.models.Model):
+class MEGAN(ks.models.Model):
 
-    def __init__(self, **kwargs):
+    def __init__(self,
+                 # convolutional network related arguments
+                 units: List[int],
+                 activation: str = 'kgcnn>leaky_relu',
+                 use_bias: bool = True,
+                 dropout_rate: float = 0.0,
+                 use_edge_features: bool = True,
+                 # node/edge importance related arguments
+                 importance_units: List[int] = [],
+                 importance_channels: int = 2,
+                 importance_dropout_rate: float = 0.0,
+                 importance_factor: float = 0.0,
+                 importance_multiplier: float = 1.0,
+                 sparsity_factor: float = 0.0,
+                 # mlp tail end related arguments
+                 final_units: List[int] = [1],
+                 final_dropout_rate: float = 0.0,
+                 final_activation: str = 'linear',
+                 regression_limits: Optional[Tuple[float, float]] = None,
+                 regression_reference: Optional[float] = None,
+                 **kwargs):
         super(MEGAN, self).__init__(self, **kwargs)
+        self.units = units
+        self.activation = activation
+        self.use_bias = use_bias
+        self.dropout_rate = dropout_rate
+        self.use_edge_features = use_edge_features
+        self.importance_units = importance_units
+        self.importance_channels = importance_channels
+        self.importance_dropout_rate = importance_dropout_rate
+        self.importance_factor = importance_factor
+        self.importance_multiplier = importance_multiplier
+        self.sparsity_factor = sparsity_factor
+        self.final_units = final_units
+        self.final_dropout_rate = final_dropout_rate
+        self.final_activation = final_activation
+        self.regression_limits = regression_limits
+        self.regression_reference = regression_reference
+
+        self.attention_layers: List[GraphBaseLayer] = []
+        for unit in self.units:
+            # lay = MultiHeadGatv2Layer(
+            #     units=units,
+            #     num_heads=self.importance_channels,
+            #     use_edge_features=self.use_edge_features,
+            #     activation=self.activation,
+            #     use_bias=self.use_bias,
+            #     has_self_loops=True,
+            #     concat_heads=True
+            # )
+            # self.attention_layers.append(lay)
+            pass
+

--- a/kgcnn/literature/MEGAN.py
+++ b/kgcnn/literature/MEGAN.py
@@ -3,8 +3,13 @@ from typing import List, Tuple, Dict, Optional, Any
 import tensorflow as tf
 import tensorflow.keras as ks
 
-from kgcnn.layers.conv.attention import AttentionHeadGATV2
 from kgcnn.layers.base import GraphBaseLayer
+from kgcnn.layers.modules import DenseEmbedding
+from kgcnn.layers.modules import ActivationEmbedding, DropoutEmbedding
+from kgcnn.layers.modules import LazyConcatenate, LazyAverage
+from kgcnn.layers.conv.gat_conv import MultiHeadGATV2Layer
+from kgcnn.layers.pooling import PoolingLocalEdges
+from kgcnn.layers.pooling import PoolingWeightedNodes, PoolingNodes
 
 
 class MEGAN(ks.models.Model):
@@ -19,6 +24,7 @@ class MEGAN(ks.models.Model):
                  # node/edge importance related arguments
                  importance_units: List[int] = [],
                  importance_channels: int = 2,
+                 importance_activation: str = 'sigmoid',
                  importance_dropout_rate: float = 0.0,
                  importance_factor: float = 0.0,
                  importance_multiplier: float = 1.0,
@@ -27,6 +33,7 @@ class MEGAN(ks.models.Model):
                  final_units: List[int] = [1],
                  final_dropout_rate: float = 0.0,
                  final_activation: str = 'linear',
+                 final_pooling: str = 'sum',
                  regression_limits: Optional[Tuple[float, float]] = None,
                  regression_reference: Optional[float] = None,
                  **kwargs):
@@ -38,6 +45,7 @@ class MEGAN(ks.models.Model):
         self.use_edge_features = use_edge_features
         self.importance_units = importance_units
         self.importance_channels = importance_channels
+        self.importance_activation = importance_activation
         self.importance_dropout_rate = importance_dropout_rate
         self.importance_factor = importance_factor
         self.importance_multiplier = importance_multiplier
@@ -45,20 +53,106 @@ class MEGAN(ks.models.Model):
         self.final_units = final_units
         self.final_dropout_rate = final_dropout_rate
         self.final_activation = final_activation
+        self.final_pooling = final_pooling
         self.regression_limits = regression_limits
         self.regression_reference = regression_reference
 
+        # ~ MAIN CONVOLUTIONAL / ATTENTION LAYERS
         self.attention_layers: List[GraphBaseLayer] = []
-        for unit in self.units:
-            # lay = MultiHeadGatv2Layer(
-            #     units=units,
-            #     num_heads=self.importance_channels,
-            #     use_edge_features=self.use_edge_features,
-            #     activation=self.activation,
-            #     use_bias=self.use_bias,
-            #     has_self_loops=True,
-            #     concat_heads=True
-            # )
-            # self.attention_layers.append(lay)
-            pass
+        for u in self.units:
+            lay = MultiHeadGATV2Layer(
+                units=u,
+                num_heads=self.importance_channels,
+                use_edge_features=self.use_edge_features,
+                activation=self.activation,
+                use_bias=self.use_bias,
+                has_self_loops=True,
+                concat_heads=True
+            )
+            self.attention_layers.append(lay)
+
+        self.lay_dropout = DropoutEmbedding(rate=self.dropout_rate)
+
+        # ~ EDGE IMPORTANCES
+        self.lay_act_importance = ActivationEmbedding(activation=self.importance_activation)
+        self.lay_concat_alphas = LazyConcatenate(axis=-1)
+
+        self.lay_pool_edges_in = PoolingLocalEdges(pooling_method='mean', pooling_index=0)
+        self.lay_pool_edges_out = PoolingLocalEdges(pooling_method='mean', pooling_index=1)
+        self.lay_average = LazyAverage()
+
+        # ~ NODE IMPORTANCES
+        self.node_importance_units = importance_units + [self.importance_channels]
+        self.node_importance_acts = ['relu' for _ in importance_units] + ['linear']
+        self.node_importance_layers = []
+        for u, act in zip(self.node_importance_units, self.node_importance_acts):
+            lay = DenseEmbedding(
+                units=u,
+                activation=act,
+                use_bias=use_bias
+            )
+            self.node_importance_layers.append(lay)
+
+        # ~ OUTPUT / MLP TAIL END
+        self.lay_pool_out = PoolingNodes(pooling_method=self.final_pooling)
+        self.lay_concat_out = LazyConcatenate(axis=-1)
+        self.lay_final_dropout = DropoutEmbedding(rate=self.final_dropout_rate)
+
+        self.final_acts = ['relu' for _ in self.final_units]
+        self.final_acts[-1] = self.final_activation
+        self.final_layers = []
+        for u, act in zip(self.final_units, self.final_acts):
+            lay = DenseEmbedding(
+                units=u,
+                activation=act,
+                use_bias=use_bias
+            )
+            self.final_layers.append(lay)
+
+        # ~ EXPLANATION ONLY TRAIN STEP
+
+    def call(self,
+             inputs):
+
+        node_input, edge_input, edge_index_input = inputs
+
+        alphas = []
+        x = node_input
+        for lay in self.attention_layers:
+            x, alpha = lay([x, edge_input, edge_index_input])
+            x = self.lay_dropout(x)
+
+            alphas.append(alpha)
+
+        alphas = self.lay_concat_alphas(alphas)
+        edge_importances = tf.reduce_sum(alphas, axis=-1, keepdims=False)
+        edge_importances = self.lay_act_importance(edge_importances)
+
+        pooled_edges_in = self.lay_pool_edges_in([node_input, edge_importances, edge_index_input])
+        pooled_edges_out = self.lay_pool_edges_out([node_input, edge_importances, edge_index_input])
+        pooled_edges = self.lay_average([pooled_edges_out, pooled_edges_in])
+
+        node_importances_tilde = x
+        for lay in self.node_importance_layers:
+            node_importances_tilde = lay(node_importances_tilde)
+
+        node_importances_tilde = self.lay_act_importance(node_importances_tilde)
+
+        node_importances = node_importances_tilde * pooled_edges
+
+        outs = []
+        for k in range(self.importance_channels):
+            node_importance_slice = tf.expand_dims(node_importances[:, :, k], axis=-1)
+            out = self.lay_pool_out(x * node_importance_slice)
+
+            outs.append(out)
+
+        out = self.lay_concat_out(outs)
+
+        for lay in self.final_layers:
+            out = lay(out)
+            self.lay_final_dropout(out)
+
+        return out, node_importances, edge_importances
+
 

--- a/kgcnn/literature/MEGAN.py
+++ b/kgcnn/literature/MEGAN.py
@@ -1,7 +1,9 @@
 from typing import List, Tuple, Dict, Optional, Any
 
+import numpy as np
 import tensorflow as tf
 import tensorflow.keras as ks
+from tensorflow.python.keras.engine import compile_utils
 
 from kgcnn.layers.base import GraphBaseLayer
 from kgcnn.layers.modules import DenseEmbedding
@@ -13,22 +15,32 @@ from kgcnn.layers.pooling import PoolingWeightedNodes, PoolingNodes
 
 
 class MEGAN(ks.models.Model):
+    """
+    MEGAN: Multi Explanation Graph Attention Network
+
+    This model currently supports graph regression and graph classification problems. It was mainly designed
+    with a focus on explainable AI (XAI). Along the main prediction, this model is able to output multiple
+    attention-based explanations for that prediction. More specifically, the model outputs node and edge
+    attributional explanations (assigning [0, 1] values to ever node / edge of the input graph) in K
+    separate explanation channels, where K can be chosen as an independent model parameter.
+    """
 
     def __init__(self,
                  # convolutional network related arguments
                  units: List[int],
-                 activation: str = 'kgcnn>leaky_relu',
+                 activation: str = "kgcnn>leaky_relu",
                  use_bias: bool = True,
                  dropout_rate: float = 0.0,
                  use_edge_features: bool = True,
                  # node/edge importance related arguments
                  importance_units: List[int] = [],
                  importance_channels: int = 2,
-                 importance_activation: str = 'sigmoid',
-                 importance_dropout_rate: float = 0.0,
+                 importance_activation: str = "sigmoid",  # do not change
+                 importance_dropout_rate: float = 0.0,  # do not change
                  importance_factor: float = 0.0,
-                 importance_multiplier: float = 1.0,
+                 importance_multiplier: float = 10.0,
                  sparsity_factor: float = 0.0,
+                 concat_heads: bool = True,
                  # mlp tail end related arguments
                  final_units: List[int] = [1],
                  final_dropout_rate: float = 0.0,
@@ -37,8 +49,52 @@ class MEGAN(ks.models.Model):
                  regression_limits: Optional[Tuple[float, float]] = None,
                  regression_reference: Optional[float] = None,
                  return_importances: bool = True,
-                 inputs: Optional = None,
                  **kwargs):
+        """
+        Args:
+            units: A list of ints where each element configures an additional attention layer. The numeric
+                value determines the number of hidden units to be used in the attention heads of that layer
+            activation: The activation function to be used within the attention layers of the network
+            use_bias: Whether the layers of the network should use bias weights at all
+            dropout_rate: The dropout rate to be applied after *each* of the attention layers of the network.
+            use_edge_features: Whether edge features should be used. Generally the network supports the
+                usage of edge features, but if the input data does not contain edge features, this should be
+                set to False.
+            importance_units: A list of ints where each element configures another dense layer in the
+                subnetwork that produces the node importance tensor from the main node embeddings. The
+                numeric value determines the number of hidden units in that layer.
+            importance_channels: The int number of explanation channels to be produced by the network. This
+                is the value referred to as "K". Note that this will also determine the number of attention
+                heads used within the attention subnetwork.
+            importance_factor: The weight of the explanation-only train step. If this is set to exactly
+                zero then the explanation train step will not be executed at all (less computationally
+                expensive)
+            importance_multiplier: An additional hyperparameter of the explanation-only train step. This
+                is essentially the scaling factor that is applied to the values of the dataset such that
+                the target values can reasonably be approximated by a sum of [0, 1] importance values.
+            sparsity_factor: The coefficient for the sparsity regularization of the node importance
+                tensor.
+            concat_heads: Whether to concat the heads of the attention subnetwork. The default is True. In
+                that case the output of each individual attention head is concatenated and the concatenated
+                vector is then used as the input of the next attention layer's heads. If this is False, the
+                vectors are average pooled instead.
+            final_units: A list of ints where each element configures another dense layer in the MLP
+                at the tail end of the network. The numeric value determines the number of the hidden units
+                in that layer. Note that the final element in this list has to be the same as the dimension
+                to be expected for the samples of the training dataset!
+            final_dropout_rate: The dropout rate to be applied after *every* layer of the final MLP.
+            final_activation: The activation to be applied at the very last layer of the MLP to produce the
+                actual output of the network.
+            final_pooling: The pooling method to be used during the global pooling phase in the network.
+            regression_limits: A tuple where the first value is the lower limit for the expected value range
+                of the regression task and teh second value the upper limit.
+            regression_reference: A reference value which is inside the range of expected values (best if
+                it was in the middle, but does not have to). Choosing different references will result
+                in different explanations.
+            return_importances: Whether the importance / explanation tensors should be returned as an output
+                of the model. If this is True, the output of the model will be a 3-tuple:
+                (output, node importances, edge importances), otherwise it is just the output itself
+        """
         super(MEGAN, self).__init__(self, **kwargs)
         self.units = units
         self.activation = activation
@@ -52,6 +108,7 @@ class MEGAN(ks.models.Model):
         self.importance_factor = importance_factor
         self.importance_multiplier = importance_multiplier
         self.sparsity_factor = sparsity_factor
+        self.concat_heads = concat_heads
         self.final_units = final_units
         self.final_dropout_rate = final_dropout_rate
         self.final_activation = final_activation
@@ -70,7 +127,7 @@ class MEGAN(ks.models.Model):
                 activation=self.activation,
                 use_bias=self.use_bias,
                 has_self_loops=True,
-                concat_heads=True
+                concat_heads=self.concat_heads
             )
             self.attention_layers.append(lay)
 
@@ -101,10 +158,12 @@ class MEGAN(ks.models.Model):
         self.lay_concat_out = LazyConcatenate(axis=-1)
         self.lay_final_dropout = DropoutEmbedding(rate=self.final_dropout_rate)
 
-        self.final_acts = ['relu' for _ in self.final_units]
+        self.final_acts = ["relu" for _ in self.final_units]
         self.final_acts[-1] = self.final_activation
+        self.final_biases = [True for _ in self.final_units]
+        self.final_biases[-1] = False
         self.final_layers = []
-        for u, act in zip(self.final_units, self.final_acts):
+        for u, act, bias in zip(self.final_units, self.final_acts, self.final_biases):
             lay = DenseEmbedding(
                 units=u,
                 activation=act,
@@ -113,27 +172,76 @@ class MEGAN(ks.models.Model):
             self.final_layers.append(lay)
 
         # ~ EXPLANATION ONLY TRAIN STEP
+        self.bce_loss = ks.losses.BinaryCrossentropy()
+        self.compiled_bce_loss = compile_utils.LossesContainer(self.bce_loss)
+
+        self.mse_loss = ks.losses.MeanSquaredError()
+        self.compiled_mse_loss = compile_utils.LossesContainer(self.mse_loss)
+
+        if self.regression_limits is not None:
+            self.regression_width = np.abs(self.regression_limits[1] - self.regression_limits[0])
+
+    def get_config(self):
+        config = super(MEGAN, self).get_config()
+        config.update({
+            "units": self.units,
+            "activation": self.activation,
+            "use_bias": self.use_bias,
+            "dropout_rate": self.dropout_rate,
+            "use_edge_features": self.use_edge_features,
+            "importance_units": self.importance_units,
+            "importance_channels": self.importance_channels,
+            "importance_activation": self.importance_activation,
+            "importance_dropout_rate": self.importance_dropout_rate,
+            "importance_factor": self.importance_factor,
+            "importance_multiplier": self.importance_multiplier,
+            "sparsity_factor": self.sparsity_factor,
+            "concat_heads": self.concat_heads,
+            "final_units": self.final_units,
+            "final_dropout_rate": self.final_dropout_rate,
+            "final_activation": self.final_activation,
+            "final_pooling": self.final_pooling,
+            "regression_limits": self.regression_limits,
+            "regression_reference": self.regression_reference,
+            "return_importances": self.return_importances
+        })
+
+        return config
+    @property
+    def doing_regression(self) -> bool:
+        return self.regression_limits is not None
 
     def call(self,
              inputs,
-             training=False):
+             training: bool = False,
+             return_importances: bool = False):
 
         node_input, edge_input, edge_index_input = inputs
-        edge_index_input = tf.cast(edge_index_input, tf.int32)
 
+        # First of all we apply all the graph convolutional / attention layers. Each of those layers outputs
+        # the attention logits alpha additional to the node embeddings. We collect all the attention logits
+        # in a list so that we can later sum them all up.
         alphas = []
         x = node_input
         for lay in self.attention_layers:
+            # x: ([batch], [N], F)
+            # alpha: ([batch], [M], K, 1)
             x, alpha = lay([x, edge_input, edge_index_input])
             if training:
                 x = self.lay_dropout(x, training=training)
 
             alphas.append(alpha)
 
+        # We sum up all the individual layers attention logit tensors and the edge importances are directly
+        # calculated by applying a sigmoid on that sum.
         alphas = self.lay_concat_alphas(alphas)
         edge_importances = tf.reduce_sum(alphas, axis=-1, keepdims=False)
         edge_importances = self.lay_act_importance(edge_importances)
 
+        # Part of the final node importance tensor is actually the pooled edge importances, so that is what
+        # we are doing here. The caveat here is that we assume undirected edges as two directed edges in
+        # opposing direction. To now achieve a symmetric pooling of these edges we have to pool in both
+        # directions and then use the average of both.
         pooled_edges_in = self.lay_pool_edges_in([node_input, edge_importances, edge_index_input])
         pooled_edges_out = self.lay_pool_edges_out([node_input, edge_importances, edge_index_input])
         pooled_edges = self.lay_average([pooled_edges_out, pooled_edges_in])
@@ -146,6 +254,9 @@ class MEGAN(ks.models.Model):
 
         node_importances = node_importances_tilde * pooled_edges
 
+        # Here we apply the global pooling. It is important to note that we do K separate pooling operations
+        # were each time we use the same node embeddings x but a different slice of the node importances as
+        # the weights! We concatenate all the individual results in the end.
         outs = []
         for k in range(self.importance_channels):
             node_importance_slice = tf.expand_dims(node_importances[:, :, k], axis=-1)
@@ -153,27 +264,159 @@ class MEGAN(ks.models.Model):
 
             outs.append(out)
 
+        # out: ([batch], F*K)
         out = self.lay_concat_out(outs)
 
+        # Now "out" is a graph embedding vector of known dimension so we can simply apply the normal dense
+        # mlp to get the final output value.
         for lay in self.final_layers:
             out = lay(out)
             if training:
                 self.lay_final_dropout(out, training=training)
 
-        if self.return_importances:
+        # Usually, the node and edge importance tensors would be direct outputs of the model as well, but
+        # we need the option to just return the output alone to be compatible with the standard model
+        # evaluation pipeline already implemented in the library.
+        if self.return_importances or return_importances:
             return out, node_importances, edge_importances
         else:
             return out
+
+    def regression_augmentation(self,
+                                out_true):
+        center_distances = tf.abs(out_true - self.regression_reference)
+        center_distances = (center_distances * self.importance_multiplier) / (0.5 * self.regression_width)
+        center_distances = tf.expand_dims(center_distances, axis=-1)
+
+        # So we need two things: a "samples" tensor and a "mask" tensor. We are going to use the samples
+        # tensor as the actual ground truth which acts as the regression target during the explanation
+        # train step. The binary values of the mask will determine at which positions a loss should
+        # actually be calculated for both of the channels
+
+        # The "lower" part is all the samples which have a target value below the reference value.
+        lo_mask = tf.where(out_true < self.regression_reference, 1.0, 0.0)
+        lo_mask = tf.expand_dims(lo_mask, axis=-1)
+
+        # The "higher" part all of the samples above reference
+        hi_mask = tf.where(out_true > self.regression_reference, 1.0, 0.0)
+        hi_mask = tf.expand_dims(hi_mask, axis=-1)
+
+        samples = tf.concat([center_distances, center_distances], axis=-1)
+        mask = tf.concat([lo_mask, hi_mask], axis=-1)
+        return samples, mask
+
+    def train_step_explanation(self, x, y):
+
+        if self.return_importances:
+            out_true, _, _ = y
+        else:
+            out_true = y
+
+        exp_loss = 0
+        with tf.GradientTape() as tape:
+
+            y_pred = self(x, training=True, return_importances=True)
+            out_pred, ni_pred, ei_pred = y_pred
+
+            # First of all we need to assemble the approximated model output, which is simply calculated
+            # by applying a global pooling operation on the corresponding slice of the node importances.
+            # So for each slice (each importance channel) we get a single value, which we then concatenate
+            # into an output vector with K dimensions.
+            outs = []
+            for k in range(self.importance_channels):
+                node_importances_slice = tf.expand_dims(ni_pred[:, :, k], axis=-1)
+                out = self.lay_pool_out(node_importances_slice)
+
+                outs.append(out)
+
+            # outs: ([batch], K)
+            outs = self.lay_concat_out(outs)
+
+            if self.doing_regression:
+                out_true, mask = self.regression_augmentation(out_true)
+                out_pred = outs
+                exp_loss = self.compiled_mse_loss(out_true * mask, out_pred * mask)
+
+            else:
+                out_pred = ks.backend.sigmoid(outs)
+                exp_loss = self.compiled_bce_loss(out_true, out_pred)
+
+            exp_loss *= self.importance_factor
+
+        # Compute gradients
+        trainable_vars = self.trainable_variables
+        exp_gradients = tape.gradient(exp_loss, trainable_vars)
+
+        # Update weights
+        self.optimizer.apply_gradients(zip(exp_gradients, trainable_vars))
+
+        return {'exp_loss': exp_loss}
+
+    def train_step(self, data):
+        if len(data) == 3:
+            x, y, sample_weight = data
+        else:
+            sample_weight = None
+            x, y = data
+
+        # The "train_step_explanation" method will execute the entire explanation train step once. This
+        # mainly involves creating an approximate solution of the original regression / classification
+        # problem using ONLY the node importances of the different channels and then performing one
+        # complete weight update based on the corresponding loss.
+        if self.importance_factor != 0:
+            exp_metrics = self.train_step_explanation(x, y)
+        else:
+            exp_metrics = {}
+
+        with tf.GradientTape() as tape:
+            y_pred = self(x, training=True)
+            if self.return_importances:
+                out_true, ni_true, ei_true = y
+                out_pred, ni_pred, ei_pred = self(x, training=True)
+                loss = self.compiled_loss(
+                    [out_true, ni_true, ei_true],
+                    [out_pred, ni_pred, ei_pred],
+                    sample_weight=sample_weight,
+                    regularization_losses=self.losses,
+                )
+            else:
+                out_true = y
+                out_pred = self(x, training=True)
+                loss = self.compiled_loss(
+                    out_true,
+                    out_pred,
+                    sample_weight=sample_weight,
+                    regularization_losses=self.losses,
+                )
+
+        trainable_vars = self.trainable_variables
+        gradients = tape.gradient(loss, trainable_vars)
+
+        self.optimizer.apply_gradients(zip(gradients, trainable_vars))
+
+        self.compiled_metrics.update_state(
+            y,
+            y_pred,
+            sample_weight=sample_weight
+        )
+
+        # Return a dict mapping metric names to current value.
+        # Note that it will include the loss (tracked in self.metrics).
+        return {
+            **{m.name: m.result() for m in self.metrics},
+            **exp_metrics
+        }
 
 
 def make_model(inputs: Optional[list] = None,
                **kwargs
                ):
 
-    megan = MEGAN(
-        **kwargs
-    )
+    # Building the actual model
+    megan = MEGAN(**kwargs)
 
+    # Wrapping the actual model inside a keras functional model to be able to account for the input shapes
+    # definitions which are provided.
     inputs = [ks.layers.Input(**kwargs) for kwargs in inputs]
     outputs = megan(inputs)
     model = ks.models.Model(inputs=inputs, outputs=outputs)

--- a/kgcnn/literature/MEGAN.py
+++ b/kgcnn/literature/MEGAN.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+
+
+class MEGAN(tf.models.Model):
+
+    def __init__(self, **kwargs):
+        super(MEGAN, self).__init__(self, **kwargs)

--- a/test/test_literature_megan.py
+++ b/test/test_literature_megan.py
@@ -29,6 +29,10 @@ class TestMegan(unittest.TestCase):
             tf.ragged.constant(ei, ragged_rank=1),
         )
 
+    def test_ragged_tensor_from_shape(self):
+        tensor = self.ragged_tensor_from_shape((None, 3), 'float32')
+
+
     # -- UNITTESTS --
 
     def test_construction_basically_works(self):

--- a/test/test_literature_megan.py
+++ b/test/test_literature_megan.py
@@ -1,0 +1,14 @@
+import unittest
+
+import tensorflow as tf
+import tensorflow.keras as ks
+
+from kgcnn.literature.MEGAN import MEGAN
+
+
+class TestMegan(unittest.TestCase):
+
+    def test_construction_basically_works(self):
+        model = MEGAN(units=[1])
+        self.assertIsInstance(model, MEGAN)
+        self.assertIsInstance(model, ks.models.Model)

--- a/test/test_literature_megan.py
+++ b/test/test_literature_megan.py
@@ -1,4 +1,6 @@
 import unittest
+import random
+import itertools
 
 import tensorflow as tf
 import tensorflow.keras as ks
@@ -8,7 +10,50 @@ from kgcnn.literature.MEGAN import MEGAN
 
 class TestMegan(unittest.TestCase):
 
+    def random_input(self, num_batches, num_features):
+        n = []
+        ei = []
+        e = []
+        for b in range(num_batches):
+            N = random.randint(5, 30)
+            node_indices = list(range(N))
+            M = random.randint(1, N - 1)
+
+            n.append([[random.random() for _ in range(num_features)] for _ in range(N)])
+            e.append([[random.random() for _ in range(num_features)] for _ in range(M)])
+            ei.append(list(zip(random.sample(node_indices, M), random.sample(node_indices, M))))
+
+        return (
+            tf.ragged.constant(n, ragged_rank=1),
+            tf.ragged.constant(e, ragged_rank=1),
+            tf.ragged.constant(ei, ragged_rank=1),
+        )
+
+    # -- UNITTESTS --
+
     def test_construction_basically_works(self):
         model = MEGAN(units=[1])
         self.assertIsInstance(model, MEGAN)
         self.assertIsInstance(model, ks.models.Model)
+
+    def test_shapes_basically_work(self):
+        num_batches = 5
+        num_features = 3
+        n, e, ei = self.random_input(num_batches=num_batches, num_features=num_features)
+
+        # We just test a bunch of different configurations for the output dimension and the number of
+        # explanation channels.
+        output_dimensions = [1, 3]
+        channel_dimensions = [2, 6]
+
+        for num_out, num_channels in itertools.product(output_dimensions, channel_dimensions):
+            model = MEGAN(
+                units=[3],
+                importance_channels=num_channels,
+                final_units=[num_out],
+            )
+
+            out, node_importances, edge_importances = model([n, e, ei])
+            self.assertEqual((num_batches, num_out), out.shape)
+            self.assertEqual((num_batches, None, num_channels), node_importances.shape)
+            self.assertEqual((num_batches, None, num_channels), node_importances.shape)

--- a/training/hyper/hyper_esol.py
+++ b/training/hyper/hyper_esol.py
@@ -1039,4 +1039,62 @@ hyper = {
             "kgcnn_version": "2.1.0"
         }
     },
+    "MEGAN": {
+        "model": {
+            "class_name": "make_model",
+            "module_name": "kgcnn.literature.MEGAN",
+            "config": {
+                'name': "MEGAN",
+                'units': [45, 40, 35],
+                'final_units': [50, 30, 1],
+                'dropout_rate': 0.3,
+                'importance_channels': 2,
+                'return_importances': False,
+                'use_edge_features': False,
+                'inputs': [{'shape': (None, 41), 'name': "node_attributes", 'dtype': 'float32', 'ragged': True},
+                           {'shape': (None, ), 'name': "edge_number", 'dtype': 'float32', 'ragged': True},
+                           {'shape': (None, 2), 'name': "edge_indices", 'dtype': 'int64', 'ragged': True}],
+            }
+        },
+        "training": {
+            "fit": {
+                "batch_size": 64,
+                "epochs": 300,
+                "validation_freq": 10,
+                "verbose": 2,
+                "callbacks": [
+                    {
+                        "class_name": "kgcnn>LinearLearningRateScheduler", "config": {
+                        "learning_rate_start": 1e-03, "learning_rate_stop": 1e-05, "epo_min": 100, "epo": 300,
+                        "verbose": 0
+                    }
+                    }
+                ]
+            },
+            "compile": {
+                "optimizer": {"class_name": "Adam", "config": {"lr": 1e-03}},
+                "loss": "mean_squared_error"
+            },
+            "cross_validation": {"class_name": "KFold",
+                                 "config": {"n_splits": 5, "random_state": 42, "shuffle": True}},
+            "scaler": {"class_name": "StandardScaler", "config": {"with_std": True, "with_mean": True, "copy": True}},
+        },
+        "data": {
+            "dataset": {
+                "class_name": "ESOLDataset",
+                "module_name": "kgcnn.data.datasets.ESOLDataset",
+                "config": {},
+                "methods": [
+                    {"set_attributes": {}},
+                    {"map_list": {"method": "set_range", "max_distance": 3, "max_neighbours": 10000}}
+                ]
+            },
+            "data_unit": "mol/L"
+        },
+        "info": {
+            "postfix": "",
+            "postfix_file": "",
+            "kgcnn_version": "2.0.3"
+        }
+    },
 }

--- a/training/hyper/hyper_esol.py
+++ b/training/hyper/hyper_esol.py
@@ -1045,10 +1045,12 @@ hyper = {
             "module_name": "kgcnn.literature.MEGAN",
             "config": {
                 'name': "MEGAN",
-                'units': [45, 40, 35],
-                'final_units': [50, 30, 1],
+                'units': [60, 50, 40, 30],
+                'importance_units': [],
+                'final_units': [50, 30, 10, 1],
                 'dropout_rate': 0.3,
-                'importance_channels': 2,
+                'final_dropout_rate': 0.00,
+                'importance_channels': 3,
                 'return_importances': False,
                 'use_edge_features': False,
                 'inputs': [{'shape': (None, 41), 'name': "node_attributes", 'dtype': 'float32', 'ragged': True},
@@ -1059,13 +1061,13 @@ hyper = {
         "training": {
             "fit": {
                 "batch_size": 64,
-                "epochs": 300,
+                "epochs": 400,
                 "validation_freq": 10,
                 "verbose": 2,
                 "callbacks": [
                     {
                         "class_name": "kgcnn>LinearLearningRateScheduler", "config": {
-                        "learning_rate_start": 1e-03, "learning_rate_stop": 1e-05, "epo_min": 100, "epo": 300,
+                        "learning_rate_start": 1e-03, "learning_rate_stop": 1e-05, "epo_min": 200, "epo": 400,
                         "verbose": 0
                     }
                     }
@@ -1094,7 +1096,7 @@ hyper = {
         "info": {
             "postfix": "",
             "postfix_file": "",
-            "kgcnn_version": "2.0.3"
+            "kgcnn_version": "2.1.0"
         }
     },
 }

--- a/training/hyper/hyper_lipop.py
+++ b/training/hyper/hyper_lipop.py
@@ -671,5 +671,83 @@ hyper = {
             "postfix_file": "",
             "kgcnn_version": "2.1.0"
         }
-    }
+    },
+    "MEGAN": {
+        "model": {
+            "class_name": "make_model",
+            "module_name": "kgcnn.literature.MEGAN",
+            "config": {
+                'name': "MEGAN",
+                'units': [60, 50, 40, 30],
+                'importance_units': [],
+                'final_units': [50, 30, 10, 1],
+                'dropout_rate': 0.4,
+                'final_dropout_rate': 0.00,
+                'importance_channels': 4,
+                'return_importances': False,
+                'use_edge_features': True,
+                'concat_heads': True,
+                'inputs': [
+                    {"shape": [None, 41], "name": "node_attributes", "dtype": "float32", "ragged": True},
+                    {"shape": [None, 11], "name": "edge_attributes", "dtype": "float32", "ragged": True},
+                    {"shape": [None, 2], "name": "edge_indices", "dtype": "int64", "ragged": True},
+                ],
+            }
+        },
+        "training": {
+            "fit": {
+                "batch_size": 128,
+                "epochs": 400,
+                "validation_freq": 10,
+                "verbose": 2,
+                "callbacks": [
+                    {
+                        "class_name": "kgcnn>LinearLearningRateScheduler",
+                        "config": {
+                            "learning_rate_start": 1e-03,
+                            "learning_rate_stop": 1e-05,
+                            "epo_min": 200,
+                            "epo": 400,
+                            "verbose": 0
+                        }
+                    }
+                ]
+            },
+            "compile": {
+                "optimizer": {
+                    "class_name": "Adam",
+                    "config": {"lr": 1e-03}
+                },
+                "loss": "mean_squared_error"
+            },
+            "cross_validation": {
+                "class_name": "KFold",
+                "config": {
+                    "n_splits": 5,
+                    "random_state": 42,
+                    "shuffle": True
+                }
+            },
+            "scaler": {
+                "class_name": "StandardScaler",
+                "config": {"with_std": True, "with_mean": True, "copy": True}
+            },
+        },
+        "data": {
+            "dataset": {
+                "class_name": "LipopDataset",
+                "module_name": "kgcnn.data.datasets.LipopDataset",
+                "config": {},
+                "methods": [
+                    {"set_attributes": {}},
+                    {"map_list": {"method": "set_range", "max_distance": 4, "max_neighbours": 10000}}
+                ]
+            },
+        },
+        "info": {
+            "postfix": "",
+            "postfix_file": "",
+            "kgcnn_version": "2.1.0"
+        }
+    },
 }


### PR DESCRIPTION
Hi :)

I added the MEGAN model from the aimat "#eye-tracking" channel. I thought it would be good to have it in a central place for future usage.

I implemented the model itself in `kgcnn/literature/MEGAN.py`. For the implementation I also had to add a custom layer in `gat_conv.py`.
I also added some test cases in `tests/test_literature_megan.py` to show that it works. I also tried it on the ESOL dataset and it seems to work. 

With the existing benchmarks, the explanations which are also generated by the model are currently not being used at all.
I thought about writing a notebook in the future to showcase the explanations as well, if you think that makes sense